### PR TITLE
Improved Unit Test Coverage from 76.2% to 82.5% with Keploy AI

### DIFF
--- a/binary/binary_test.go
+++ b/binary/binary_test.go
@@ -1,8 +1,9 @@
 package binary
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestQname(t *testing.T) {
@@ -21,4 +22,28 @@ func TestUint16(t *testing.T) {
 	assert.Equal(t, "00000000 00000011", Uint16(3))
 	assert.Equal(t, "00000000 01111001", Uint16(121))
 	assert.Equal(t, "00000011 11101000", Uint16(1000))
+}
+
+// Test generated using Keploy
+func TestQname_RootDomain(t *testing.T) {
+	expected := "00000000"
+	result := Qname(".")
+	if result != expected {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+// Test generated using Keploy
+func TestUint32(t *testing.T) {
+	expected := "00000000 00000000 00000000 00000001"
+	result := Uint32(1)
+	if result != expected {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+
+	expected = "00000000 00000000 00000011 11101000"
+	result = Uint32(1000)
+	if result != expected {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
 }

--- a/internal/markdowntest/plugin_test.go
+++ b/internal/markdowntest/plugin_test.go
@@ -1,0 +1,79 @@
+package markdowntest
+
+import (
+    "testing"
+
+    "github.com/miekg/dns"
+)
+
+// Test generated using Keploy
+func TestSimplePlugin_Name(t *testing.T) {
+	plugin := &SimplePlugin{}
+	expected := "module-1"
+	result := plugin.Name()
+	if result != expected {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+// Test generated using Keploy
+func TestPluginWithDescription_Name(t *testing.T) {
+	plugin := &PluginWithDescription{}
+	expected := "module-2"
+	result := plugin.Name()
+	if result != expected {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+// Test generated using Keploy
+func TestPluginWithDescription_Description(t *testing.T) {
+	plugin := &PluginWithDescription{}
+	expected := "this is a description"
+	result := plugin.Description()
+	if result != expected {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+// Test generated using Keploy
+func TestPluginWithDescriptionAndViolation_Examples(t *testing.T) {
+	plugin := &PluginWithDescriptionAndViolation{}
+	expected := "this is another example"
+	result := plugin.Examples()
+	if result != expected {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+// Test generated using Keploy
+func TestSimplePlugin_Reply(t *testing.T) {
+	plugin := &SimplePlugin{}
+	msg := &dns.Msg{}
+	result := plugin.Reply(msg)
+	if result != nil {
+		t.Errorf("Expected nil, got %v", result)
+	}
+}
+
+
+// Test generated using Keploy
+func TestPluginWithDescription_Reply_NilInput(t *testing.T) {
+    plugin := &PluginWithDescription{}
+    var msg *dns.Msg
+    result := plugin.Reply(msg)
+    if result != nil {
+        t.Errorf("Expected nil, got %v", result)
+    }
+}
+
+
+// Test generated using Keploy
+func TestPluginWithDescriptionAndViolation_Reply_NilInput(t *testing.T) {
+    plugin := &PluginWithDescriptionAndViolation{}
+    var msg *dns.Msg
+    result := plugin.Reply(msg)
+    if result != nil {
+        t.Errorf("Expected nil, got %v", result)
+    }
+}

--- a/internal/plugin/echo/plugin_test.go
+++ b/internal/plugin/echo/plugin_test.go
@@ -1,11 +1,11 @@
 package echo
 
 import (
-	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"testing"
+    "github.com/miekg/dns"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "go.uber.org/zap"
+    "testing"
 )
 
 func TestPlugin_Reply(t *testing.T) {
@@ -39,3 +39,32 @@ func TestPlugin_Reply(t *testing.T) {
 		})
 	})
 }
+
+// Test generated using Keploy
+func TestPlugin_Reply_InvalidFirstLabel(t *testing.T) {
+    m := new(dns.Msg)
+    m.SetQuestion(dns.Fqdn("invalid.foo.com"), dns.TypeA)
+    m.Id = 12345
+    m.SetEdns0(1232, true)
+
+    p := NewPlugin(zap.NewNop())
+    b := p.Reply(m)
+    require.Nil(t, b)
+}
+
+
+// Test generated using Keploy
+func TestPlugin_Description(t *testing.T) {
+    p := NewPlugin(zap.NewNop())
+    desc := p.Description()
+    require.Equal(t, "This plugin reply the exact same bytes it receives.", desc)
+}
+
+
+// Test generated using Keploy
+func TestPlugin_Examples(t *testing.T) {
+    p := NewPlugin(zap.NewNop())
+    example := p.Examples()
+    require.Equal(t, "`dig @localhost echo.foo.com`", example)
+}
+

--- a/internal/plugin/ednsformerr/plugin_test.go
+++ b/internal/plugin/ednsformerr/plugin_test.go
@@ -1,13 +1,14 @@
 package ednsformerr
 
 import (
-	"fmt"
-	"github.com/learn-dns-security-com/gothdns/binary"
-	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"testing"
+    "fmt"
+    "github.com/learn-dns-security-com/gothdns/binary"
+    "github.com/miekg/dns"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "go.uber.org/zap"
+    "testing"
+    "github.com/learn-dns-security-com/gothdns/internal/plugin"
 )
 
 func TestPlugin_Reply(t *testing.T) {
@@ -76,3 +77,33 @@ func TestPlugin_Reply(t *testing.T) {
 		})
 	})
 }
+
+// Test generated using Keploy
+func TestPlugin_Description(t *testing.T) {
+    p := NewPlugin(zap.NewNop())
+    description := p.Description()
+    expected := "This plugin reply FORMERR for any query with EDNS and a valid IP for query without EDNS.\nSupport for A record only."
+    assert.Equal(t, expected, description)
+}
+
+
+// Test generated using Keploy
+func TestPlugin_Examples(t *testing.T) {
+    p := NewPlugin(zap.NewNop())
+    examples := p.Examples()
+    expected := "`dig @localhost ednsformerr.foo.com +edns`"
+    assert.Equal(t, expected, examples)
+}
+
+
+// Test generated using Keploy
+func TestPlugin_DNSViolation(t *testing.T) {
+    p := NewPlugin(zap.NewNop())
+    violation := p.DNSViolation()
+    expected := plugin.Violation{
+        Identifier: "DVE-2020-0001",
+        Link:       "https://github.com/dns-violations/dns-violations/blob/master/2020/DVE-2020-0001.md",
+    }
+    assert.Equal(t, expected, violation)
+}
+

--- a/internal/plugin/emptyresponse/plugin_test.go
+++ b/internal/plugin/emptyresponse/plugin_test.go
@@ -1,11 +1,11 @@
 package emptyresponse
 
 import (
-	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"testing"
+    "github.com/miekg/dns"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "go.uber.org/zap"
+    "testing"
 )
 
 func TestPlugin_Reply(t *testing.T) {
@@ -34,3 +34,35 @@ func TestPlugin_Reply(t *testing.T) {
 		})
 	})
 }
+
+// Test generated using Keploy
+func TestPlugin_Reply_InvalidQuestionName(t *testing.T) {
+    m := new(dns.Msg)
+    m.SetQuestion(dns.Fqdn("invalid.foo.com"), dns.TypeA)
+
+    p := NewPlugin(zap.NewNop())
+    b := p.Reply(m)
+
+    require.Nil(t, b)
+}
+
+
+// Test generated using Keploy
+func TestPlugin_Description(t *testing.T) {
+    p := NewPlugin(zap.NewNop())
+    desc := p.Description()
+
+    expected := "This plugin reply an empty message."
+    require.Equal(t, expected, desc)
+}
+
+
+// Test generated using Keploy
+func TestPlugin_Examples(t *testing.T) {
+    p := NewPlugin(zap.NewNop())
+    examples := p.Examples()
+
+    expected := "`dig @localhost emptyresponse.foo.com`"
+    require.Equal(t, expected, examples)
+}
+

--- a/internal/plugin/headerquestion/plugin_test.go
+++ b/internal/plugin/headerquestion/plugin_test.go
@@ -2,12 +2,13 @@ package headerquestion
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/learn-dns-security-com/gothdns/binary"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestPlugin_Reply(t *testing.T) {
@@ -56,4 +57,15 @@ func TestPlugin_Reply(t *testing.T) {
 			require.Nil(t, b)
 		})
 	})
+}
+
+// Test generated using Keploy
+func TestPlugin_Reply_InvalidQuestionName(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn("invalid.foo.com"), dns.TypeA)
+	m.Id = 12345
+
+	p := NewPlugin(zap.NewNop())
+	b := p.Reply(m)
+	require.Nil(t, b)
 }

--- a/internal/plugin/helper_test.go
+++ b/internal/plugin/helper_test.go
@@ -1,0 +1,42 @@
+package plugin
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// Test generated using Keploy
+func TestReplyWithDefaultARecord_ValidInput(t *testing.T) {
+	// Set up DefaultIp if not already set
+	if DefaultIp == nil {
+		DefaultIp = net.ParseIP("192.0.2.1")
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+	result, err := ReplyWithDefaultARecord(msg)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if result == nil {
+		t.Fatalf("Expected non-nil result")
+	}
+	response := new(dns.Msg)
+	err = response.Unpack(result)
+	if err != nil {
+		t.Fatalf("Failed to unpack result: %v", err)
+	}
+	if len(response.Answer) != 1 {
+		t.Fatalf("Expected 1 answer, got %d", len(response.Answer))
+	}
+	aRecord, ok := response.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("Expected A record, got %T", response.Answer[0])
+	}
+	expectedIp := DefaultIp.String()
+	if aRecord.A.String() != expectedIp {
+		t.Errorf("Expected IP %v, got %v", expectedIp, aRecord.A.String())
+	}
+}

--- a/internal/plugin/nodobitsupport/plugin_test.go
+++ b/internal/plugin/nodobitsupport/plugin_test.go
@@ -1,11 +1,12 @@
 package nodobitsupport
 
 import (
+	"testing"
+
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestPlugin_Reply(t *testing.T) {
@@ -85,4 +86,32 @@ func TestPlugin_Reply(t *testing.T) {
 			assert.Equal(t, "127.0.0.1", r.Answer[0].(*dns.A).A.String(), r.String())
 		})
 	})
+}
+
+// Test generated using Keploy
+func TestPlugin_Reply_FirstLabelMismatch_ReturnsNil(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn("invalid-label.foo.com"), dns.TypeA)
+	m.Id = 12345
+	m.SetEdns0(1232, false)
+
+	p := NewPlugin(zap.NewNop())
+	b := p.Reply(m)
+	require.Nil(t, b)
+}
+
+// Test generated using Keploy
+func TestPlugin_Description_ReturnsCorrectDescription(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	description := p.Description()
+	expected := "This plugin discard any packet that comes with EDNS0 DO bit to zero. Packet with DO to 1 will give a proper IP.\nSupport for A record only."
+	assert.Equal(t, expected, description)
+}
+
+// Test generated using Keploy
+func TestPlugin_DNSViolation_ReturnsCorrectDetails(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	violation := p.DNSViolation()
+	assert.Equal(t, "DVE-2018-0001", violation.Identifier)
+	assert.Equal(t, "https://github.com/dns-violations/dns-violations/blob/master/2018/DVE-2018-0001.md", violation.Link)
 }

--- a/internal/plugin/noednssupport/plugin_test.go
+++ b/internal/plugin/noednssupport/plugin_test.go
@@ -1,12 +1,13 @@
 package noednssupport
 
 import (
+	"testing"
+
 	"github.com/learn-dns-security-com/gothdns/internal/plugin"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestPlugin_Reply(t *testing.T) {
@@ -62,4 +63,42 @@ func TestPlugin_Reply(t *testing.T) {
 			assert.Equal(t, "127.0.0.1", r.Answer[0].(*dns.A).A.String(), r.String())
 		})
 	})
+}
+
+// Test generated using Keploy
+func TestPlugin_Reply_FirstLabelMismatch_ReturnsNil(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn("invalid.foo.com"), dns.TypeA)
+	m.Id = 12345
+
+	p := NewPlugin(zap.NewNop())
+	b := p.Reply(m)
+	require.Nil(t, b)
+}
+
+// Test generated using Keploy
+func TestPlugin_Description_ReturnsCorrectString(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	expected := "This plugin discard any packet that comes with OPT record.\nSupport for A record only."
+	actual := p.Description()
+	require.Equal(t, expected, actual)
+}
+
+// Test generated using Keploy
+func TestPlugin_Examples_ReturnsCorrectString(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	expected := "`dig @localhost noednssupport.foo.com +edns`"
+	actual := p.Examples()
+	require.Equal(t, expected, actual)
+}
+
+// Test generated using Keploy
+func TestPlugin_DNSViolation_ReturnsCorrectDetails(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	expected := plugin.Violation{
+		Identifier: "DVE-2020-0004",
+		Link:       "https://github.com/dns-violations/dns-violations/blob/master/2020/DVE-2020-0004.md",
+	}
+	actual := p.DNSViolation()
+	require.Equal(t, expected, actual)
 }

--- a/internal/plugin/nullbytes/plugin_test.go
+++ b/internal/plugin/nullbytes/plugin_test.go
@@ -2,11 +2,12 @@ package nullbytes
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestPlugin_Reply(t *testing.T) {
@@ -69,4 +70,31 @@ func TestPlugin_Reply(t *testing.T) {
 			require.Nil(t, b)
 		})
 	})
+}
+
+// Test generated using Keploy
+func TestPlugin_Reply_InvalidQuestionName_ReturnsNil(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn("invalid.foo.com"), dns.TypeA)
+
+	p := NewPlugin(zap.NewNop())
+	b := p.Reply(m)
+
+	require.Nil(t, b)
+}
+
+// Test generated using Keploy
+func TestPlugin_Description_ReturnsCorrectString(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	desc := p.Description()
+
+	assert.Equal(t, "This plugin responds with only NULL bytes.", desc)
+}
+
+// Test generated using Keploy
+func TestPlugin_Examples_ReturnsCorrectString(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	examples := p.Examples()
+
+	assert.Equal(t, "`dig @localhost nullbytes.foo.com` with 1 NULL byte or `dig @localhost nullbytes.20.foo.com` for 20 NULL bytes", examples)
 }

--- a/internal/plugin/soawrongsection/plugin_test.go
+++ b/internal/plugin/soawrongsection/plugin_test.go
@@ -1,11 +1,13 @@
 package soawrongsection
 
 import (
+	"testing"
+
+	"github.com/learn-dns-security-com/gothdns/internal/plugin"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestPlugin_Reply(t *testing.T) {
@@ -48,4 +50,42 @@ func TestPlugin_Reply(t *testing.T) {
 			require.Nil(t, b)
 		})
 	})
+}
+
+// Test generated using Keploy
+func TestPlugin_Reply_FirstLabelMismatch_ReturnsNil(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn("wronglabel.foo.com"), dns.TypeSOA)
+
+	p := NewPlugin(zap.NewNop())
+	b := p.Reply(m)
+
+	require.Nil(t, b)
+}
+
+// Test generated using Keploy
+func TestPlugin_Description_ReturnsCorrectString(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	description := p.Description()
+	expected := "This plugin reply to SOA query by setting up the SOA in AUTHORITY section rather than ANSWER.\nSupport for SOA record only."
+	require.Equal(t, expected, description)
+}
+
+// Test generated using Keploy
+func TestPlugin_Examples_ReturnsCorrectString(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	examples := p.Examples()
+	expected := "`dig @localhost soawrongsection.foo.com`"
+	require.Equal(t, expected, examples)
+}
+
+// Test generated using Keploy
+func TestPlugin_DNSViolation_ReturnsCorrectViolation(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	violation := p.DNSViolation()
+	expected := plugin.Violation{
+		Identifier: "DVE-2020-0002",
+		Link:       "https://github.com/dns-violations/dns-violations/blob/master/2020/DVE-2020-0002.md",
+	}
+	require.Equal(t, expected, violation)
 }

--- a/internal/plugin/staticip/plugin_test.go
+++ b/internal/plugin/staticip/plugin_test.go
@@ -1,12 +1,13 @@
 package staticip
 
 import (
+	"testing"
+
 	"github.com/learn-dns-security-com/gothdns/internal/plugin"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestPlugin_Reply(t *testing.T) {
@@ -93,4 +94,20 @@ func TestPlugin_Reply(t *testing.T) {
 			require.Nil(t, b)
 		})
 	})
+}
+
+// Test generated using Keploy
+func TestPlugin_Description(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	description := p.Description()
+	expected := "This plugin allow you to get returned a static IP (by default `127.0.0.1`) or define your own from the query.\nOnly support A record for now."
+	assert.Equal(t, expected, description)
+}
+
+// Test generated using Keploy
+func TestPlugin_Examples(t *testing.T) {
+	p := NewPlugin(zap.NewNop())
+	examples := p.Examples()
+	expected := "`dig @localhost staticip.foo.com` or `dig @localhost staticip.1.2.3.4.foo.com` to get `1.2.3.4` back in the ANSWER section."
+	assert.Equal(t, expected, examples)
 }

--- a/internal/plugintest/writer_test.go
+++ b/internal/plugintest/writer_test.go
@@ -1,0 +1,88 @@
+package plugintest
+
+import (
+    "testing"
+    "net"
+    "github.com/miekg/dns"
+)
+
+
+// Test generated using Keploy
+func TestBytesReceived_Shift_Empty(t *testing.T) {
+    var br BytesReceived
+    result := br.Shift()
+    if result != nil {
+        t.Errorf("Expected nil, got %v", result)
+    }
+}
+
+// Test generated using Keploy
+func TestMessagesReceived_Shift_Empty(t *testing.T) {
+    var mr MessagesReceived
+    result := mr.Shift()
+    if result != nil {
+        t.Errorf("Expected nil, got %v", result)
+    }
+}
+
+
+// Test generated using Keploy
+func TestResponseWriter_LocalAddr(t *testing.T) {
+    rw := &ResponseWriter{}
+    addr := rw.LocalAddr()
+    if addr == nil {
+        t.Errorf("Expected non-nil address, got nil")
+    }
+}
+
+
+// Test generated using Keploy
+func TestResponseWriter_RemoteAddr(t *testing.T) {
+    rw := &ResponseWriter{}
+    addr := rw.RemoteAddr()
+    udpAddr, ok := addr.(*net.UDPAddr)
+    if !ok {
+        t.Errorf("Expected *net.UDPAddr, got %T", addr)
+    }
+    if udpAddr.IP.String() != "127.0.0.1" {
+        t.Errorf("Expected IP 127.0.0.1, got %v", udpAddr.IP)
+    }
+    if udpAddr.Port < 1024 || udpAddr.Port > 51023 {
+        t.Errorf("Expected port in range 1024-51023, got %v", udpAddr.Port)
+    }
+}
+
+
+// Test generated using Keploy
+func TestResponseWriter_WriteMsg(t *testing.T) {
+    rw := &ResponseWriter{}
+    msg := &dns.Msg{Question: []dns.Question{{Name: "example.com."}}}
+    err := rw.WriteMsg(msg)
+    if err != nil {
+        t.Errorf("Expected no error, got %v", err)
+    }
+    if len(rw.Messages) != 1 || rw.Messages[0] != msg {
+        t.Errorf("Expected Messages to contain the written message, got %v", rw.Messages)
+    }
+}
+
+
+// Test generated using Keploy
+func TestResponseWriter_Close(t *testing.T) {
+    rw := &ResponseWriter{}
+    err := rw.Close()
+    if err != nil {
+        t.Errorf("Expected no error, got %v", err)
+    }
+}
+
+
+// Test generated using Keploy
+func TestResponseWriter_TsigStatus(t *testing.T) {
+    rw := &ResponseWriter{}
+    err := rw.TsigStatus()
+    if err != nil {
+        t.Errorf("Expected nil, got %v", err)
+    }
+}
+

--- a/main_test.go
+++ b/main_test.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
 	"github.com/learn-dns-security-com/gothdns/internal/config"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
-	"os"
-	"syscall"
-	"testing"
-	"time"
 )
 
 func TestMainFunction(t *testing.T) {

--- a/packet/parser_test.go
+++ b/packet/parser_test.go
@@ -2,12 +2,13 @@ package packet
 
 import (
 	"fmt"
+	"net"
+	"testing"
+
 	"github.com/learn-dns-security-com/gothdns/binary"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net"
-	"testing"
 )
 
 func TestPacketParser_Question(t *testing.T) {
@@ -209,4 +210,52 @@ func TestPacketParser_Answer(t *testing.T) {
 			fmt.Sprintf("%.8b", b),
 		)
 	})
+}
+
+// Test generated using Keploy
+func TestNewPacketParser_EmptyByteSlice_Error(t *testing.T) {
+	pp, err := NewPacketParser([]byte{})
+	require.NotNil(t, pp)
+	require.NoError(t, err)
+}
+
+// Test generated using Keploy
+func TestPacketParser_Header_SmallPacket_Error(t *testing.T) {
+	pp, err := NewPacketParser([]byte{0x00, 0x01, 0x02, 0x03, 0x04})
+	require.NoError(t, err)
+
+	header, err := pp.Header()
+	require.Nil(t, header)
+	require.EqualError(t, err, "packet is too small to have an header")
+}
+
+// Test generated using Keploy
+func TestPacketParser_ANCOUNT_SmallPacket_Error(t *testing.T) {
+	pp, err := NewPacketParser([]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06})
+	require.NoError(t, err)
+
+	ancount, err := pp.ANCOUNT()
+	require.Equal(t, uint16(0), ancount)
+	require.EqualError(t, err, "packet is too small to have ANCOUNT flag")
+}
+
+// Test generated using Keploy
+func TestPacketParser_Read_InvalidSlice_Error(t *testing.T) {
+	pp, err := NewPacketParser([]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07})
+	require.NoError(t, err)
+
+	ps := PacketSlice{start: 0, end: 20}
+	data, err := pp.Read(ps)
+	require.Nil(t, data)
+	require.EqualError(t, err, "packet too small")
+}
+
+// Test generated using Keploy
+func TestPacketParser_Answer_InvalidQuestion_Error(t *testing.T) {
+	pp, err := NewPacketParser([]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07})
+	require.NoError(t, err)
+
+	ps, err := pp.Answer()
+	require.Equal(t, PacketSlice{}, ps)
+	require.Error(t, err)
 }


### PR DESCRIPTION
Hey Vincent!
 I’ve added new unit tests to the Go codebase while testing the capabilities of my [Keploy AI testing agent](https://marketplace.visualstudio.com/items?itemName=Keploy.keployio&ssr=false#version-history). The tests ensure reliable coverage by validating code builds, eliminating flaky tests, and improving overall test stability. Here’s what the AI checks for:
* Ensures new tests build without errors.
* Confirms no flaky tests are introduced.
* Enhances coverage for previously untested areas.
Coverage Breakdown:
* Total Coverage Increased: 51.6% to 54.8%

Command to run 
```
go test ./... -cover -coverprofile=coverage.out && go tool cover -func=coverage.out | tail -n 1
```


let me know if there is anything else I can add. 

Before:
<img width="1106" alt="image" src="https://github.com/user-attachments/assets/34856708-bbea-4545-ae15-a82f7b13229c" />

After:
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/f5632749-fe8a-47de-8c8c-0ef3ac5db15c" />
